### PR TITLE
feature: Add Avalonia.NameGenerator for x:Name refs generation

### DIFF
--- a/KeyboardSwitch.Settings/KeyboardSwitch.Settings.csproj
+++ b/KeyboardSwitch.Settings/KeyboardSwitch.Settings.csproj
@@ -85,6 +85,7 @@
     <PackageReference Include="System.Interactive" Version="5.0.0" />
     <PackageReference Include="System.Interactive.Async" Version="5.0.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="XamlNameReferenceGenerator" Version="0.2.1-preview" />
   </ItemGroup>
 
   <ItemGroup>
@@ -184,5 +185,8 @@
     <None Update="Views\AboutView.xaml">
       <Generator>MSBuild:Compile</Generator>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="**\*.xaml" />
   </ItemGroup>
 </Project>

--- a/KeyboardSwitch.Settings/Views/AboutView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/AboutView.xaml.cs
@@ -15,7 +15,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class AboutView : ReactiveUserControl<AboutViewModel>
+    public partial class AboutView : ReactiveUserControl<AboutViewModel>
     {
         public AboutView()
         {
@@ -47,27 +47,7 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBlock VersionTextBlock { get; set; } = null!;
-        private Button CheckForUpdatesButton { get; set; } = null!;
-        private TextBlock NoNewVersionsTextBlock { get; set; } = null!;
-        private Button ViewDocsButton { get; set; } = null!;
-
-        private TextBlock NewVersionTextBlock { get; set; } = null!;
-        private Button GetNewVersionButton { get; set; } = null!;
-        private TextBlock GetNewVersionHintTextBlock { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-            this.VersionTextBlock = this.FindControl<TextBlock>(nameof(this.VersionTextBlock));
-            this.CheckForUpdatesButton = this.FindControl<Button>(nameof(this.CheckForUpdatesButton));
-            this.NoNewVersionsTextBlock = this.FindControl<TextBlock>(nameof(this.NoNewVersionsTextBlock));
-            this.ViewDocsButton = this.FindControl<Button>(nameof(this.ViewDocsButton));
-
-            this.NewVersionTextBlock = this.FindControl<TextBlock>(nameof(this.NewVersionTextBlock));
-            this.GetNewVersionButton = this.FindControl<Button>(nameof(this.GetNewVersionButton));
-            this.GetNewVersionHintTextBlock = this.FindControl<TextBlock>(nameof(this.GetNewVersionHintTextBlock));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BindElementsVisibility(CompositeDisposable disposables)
         {

--- a/KeyboardSwitch.Settings/Views/CharMappingView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/CharMappingView.xaml.cs
@@ -12,7 +12,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class CharMappingView : ReactiveUserControl<CharMappingViewModel>
+    public partial class CharMappingView : ReactiveUserControl<CharMappingViewModel>
     {
         public CharMappingView()
         {
@@ -28,36 +28,7 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private ItemsControl Layouts { get; set; } = null!;
-        private Button AutoConfigureButton { get; set; } = null!;
-
-        private TextBlock NewLayoutsTextBlock { get; set; } = null!;
-        private StackPanel RemoveLayoutsPanel { get; set; } = null!;
-        private Button RemoveLayoutsButton { get; set; } = null!;
-
-        private StackPanel ActionPanel { get; set; } = null!;
-        private Button SaveButton { get; set; } = null!;
-        private Button CancelButton { get; set; } = null!;
-
-        private TextBlock RestartServiceTextBlock { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.Layouts = this.FindControl<ItemsControl>(nameof(Layouts));
-            this.AutoConfigureButton = this.FindControl<Button>(nameof(this.AutoConfigureButton));
-
-            this.NewLayoutsTextBlock = this.Find<TextBlock>(nameof(this.NewLayoutsTextBlock));
-            this.RemoveLayoutsPanel = this.Find<StackPanel>(nameof(this.RemoveLayoutsPanel));
-            this.RemoveLayoutsButton = this.Find<Button>(nameof(this.RemoveLayoutsButton));
-
-            this.ActionPanel = this.FindControl<StackPanel>(nameof(ActionPanel));
-            this.SaveButton = this.FindControl<Button>(nameof(this.SaveButton));
-            this.CancelButton = this.FindControl<Button>(nameof(this.CancelButton));
-
-            this.RestartServiceTextBlock = this.Find<TextBlock>(nameof(this.RestartServiceTextBlock));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BindCommands(CompositeDisposable disposables)
         {

--- a/KeyboardSwitch.Settings/Views/CharacterView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/CharacterView.xaml.cs
@@ -17,7 +17,7 @@ using static KeyboardSwitch.Common.Constants;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class CharacterView : ReactiveUserControl<CharacterViewModel>
+    public partial class CharacterView : ReactiveUserControl<CharacterViewModel>
     {
         public CharacterView()
         {
@@ -42,13 +42,7 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBox CharBox { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-            this.CharBox = this.FindControl<TextBox>(nameof(this.CharBox));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private string KeyToString(KeyEventArgs e)
             => e.Key switch

--- a/KeyboardSwitch.Settings/Views/ConverterSettingsView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/ConverterSettingsView.xaml.cs
@@ -12,7 +12,7 @@ using ReactiveUI.Validation.Extensions;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class ConverterSettingsView : ReactiveUserControl<ConverterSettingsViewModel>
+    public partial class ConverterSettingsView : ReactiveUserControl<ConverterSettingsViewModel>
     {
         public ConverterSettingsView()
         {
@@ -59,36 +59,6 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private ItemsControl Layouts { get; set; } = null!;
-        private Button AddLayoutButton { get; set; } = null!;
-        private Button AutoConfigureButton { get; set; } = null!;
-
-        private TextBlock CustomLayoutsValidationTextBlock { get; set; } = null!;
-
-        private StackPanel ActionPanel { get; set; } = null!;
-        private Button SaveButton { get; set; } = null!;
-        private Button CancelButton { get; set; } = null!;
-
-        private DockPanel MainPanel { get; set; } = null!;
-        private ContentControl LoadableLayoutsControl { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.Layouts = this.FindControl<ItemsControl>(nameof(this.Layouts));
-            this.AddLayoutButton = this.FindControl<Button>(nameof(this.AddLayoutButton));
-            this.AutoConfigureButton = this.FindControl<Button>(nameof(this.AutoConfigureButton));
-
-            this.CustomLayoutsValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.CustomLayoutsValidationTextBlock));
-
-            this.ActionPanel = this.FindControl<StackPanel>(nameof(this.ActionPanel));
-            this.SaveButton = this.FindControl<Button>(nameof(this.SaveButton));
-            this.CancelButton = this.FindControl<Button>(nameof(this.CancelButton));
-
-            this.MainPanel = this.FindControl<DockPanel>(nameof(this.MainPanel));
-            this.LoadableLayoutsControl = this.FindControl<ContentControl>(nameof(this.LoadableLayoutsControl));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/ConverterView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/ConverterView.xaml.cs
@@ -21,7 +21,7 @@ using ReactiveUI.Validation.Extensions;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class ConverterView : ReactiveUserControl<ConverterViewModel>
+    public partial class ConverterView : ReactiveUserControl<ConverterViewModel>
     {
         public ConverterView()
         {
@@ -35,40 +35,7 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBlock TooFewLayoutsTextBlock { get; set; } = null!;
-        private Grid ConverterGrid { get; set; } = null!;
-
-        private TextBox SourceTextBox { get; set; } = null!;
-        private TextBox TargetTextBox { get; set; } = null!;
-
-        private ComboBox SourceLayoutComboBox { get; set; } = null!;
-        private ComboBox TargetLayoutComboBox { get; set; } = null!;
-
-        private Button SwapButton { get; set; } = null!;
-        private Button ConvertButton { get; set; } = null!;
-        private Button ClearButton { get; set; } = null!;
-
-        private TextBlock LayoutsValidationTextBlock { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.TooFewLayoutsTextBlock = this.FindControl<TextBlock>(nameof(this.TooFewLayoutsTextBlock));
-            this.ConverterGrid = this.FindControl<Grid>(nameof(this.ConverterGrid));
-
-            this.SourceTextBox = this.FindControl<TextBox>(nameof(this.SourceTextBox));
-            this.TargetTextBox = this.FindControl<TextBox>(nameof(this.TargetTextBox));
-
-            this.SourceLayoutComboBox = this.FindControl<ComboBox>(nameof(this.SourceLayoutComboBox));
-            this.TargetLayoutComboBox = this.FindControl<ComboBox>(nameof(this.TargetLayoutComboBox));
-
-            this.SwapButton = this.FindControl<Button>(nameof(this.SwapButton));
-            this.ConvertButton = this.FindControl<Button>(nameof(this.ConvertButton));
-            this.ClearButton = this.FindControl<Button>(nameof(this.ClearButton));
-
-            this.LayoutsValidationTextBlock = this.FindControl<TextBlock>(nameof(this.LayoutsValidationTextBlock));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BindConverterVisibility(CompositeDisposable disposables)
         {

--- a/KeyboardSwitch.Settings/Views/CustomLayoutView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/CustomLayoutView.xaml.cs
@@ -14,7 +14,7 @@ using ReactiveUI.Validation.Extensions;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class CustomLayoutView : ReactiveUserControl<CustomLayoutViewModel>
+    public partial class CustomLayoutView : ReactiveUserControl<CustomLayoutViewModel>
     {
         public CustomLayoutView()
         {
@@ -43,23 +43,6 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBox NameTextBox { get; set; } = null!;
-        private TextBox CharsTextBox { get; set; } = null!;
-        private Button DeleteButton { get; set; } = null!;
-
-        private TextBlock NameEmptyTextBlock { get; set; } = null!;
-        private TextBlock DuplicateCharsTextBlock { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.NameTextBox = this.FindControl<TextBox>(nameof(this.NameTextBox));
-            this.CharsTextBox = this.FindControl<TextBox>(nameof(this.CharsTextBox));
-            this.DeleteButton = this.FindControl<Button>(nameof(this.DeleteButton));
-
-            this.NameEmptyTextBlock = this.FindControl<TextBlock>(nameof(this.NameEmptyTextBlock));
-            this.DuplicateCharsTextBlock = this.FindControl<TextBlock>(nameof(this.DuplicateCharsTextBlock));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/HotKeySwitchView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/HotKeySwitchView.xaml.cs
@@ -16,7 +16,7 @@ using ReactiveUI.Validation.Extensions;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class HotKeySwitchView : ReactiveUserControl<HotKeySwitchViewModel>
+    public partial class HotKeySwitchView : ReactiveUserControl<HotKeySwitchViewModel>
     {
         public HotKeySwitchView()
         {
@@ -59,43 +59,9 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private ComboBox ModifierKeysComboBox { get; set; } = null!;
-
-        private ContentControl ForwardContent { get; set; } = null!;
-        private ContentControl BackwardContent { get; set; } = null!;
-
-        private TextBlock ForwardValidationRequiredTextBlock { get; set; } = null!;
-        private TextBlock ForwardValidationTextBlock { get; set; } = null!;
-
-        private TextBlock BackwardValidationRequiredTextBlock { get; set; } = null!;
-        private TextBlock BackwardValidationTextBlock { get; set; } = null!;
-
-        private TextBlock SwitchMethodsValidationTextBlock { get; set; } = null!;
-
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            this.ModifierKeysComboBox = this.FindControl<ComboBox>(nameof(this.ModifierKeysComboBox));
-
-            this.ForwardContent = this.FindControl<ContentControl>(nameof(this.ForwardContent));
-            this.BackwardContent = this.FindControl<ContentControl>(nameof(this.BackwardContent));
-
-            this.ForwardValidationRequiredTextBlock = this.FindControl<TextBlock>(
-                nameof(this.ForwardValidationRequiredTextBlock));
-
-            this.ForwardValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.ForwardValidationTextBlock));
-
-            this.BackwardValidationRequiredTextBlock = this.FindControl<TextBlock>(
-                nameof(this.BackwardValidationRequiredTextBlock));
-
-            this.BackwardValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.BackwardValidationTextBlock));
-
-            this.SwitchMethodsValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.SwitchMethodsValidationTextBlock));
-
             this.ModifierKeysComboBox.Items = new List<ModifierKeys>
                 {
                     ModifierKeys.Alt, ModifierKeys.Ctrl, ModifierKeys.Shift

--- a/KeyboardSwitch.Settings/Views/LayoutView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/LayoutView.xaml.cs
@@ -11,7 +11,7 @@ using ReactiveUI.Validation.Extensions;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class LayoutView : ReactiveUserControl<LayoutViewModel>
+    public partial class LayoutView : ReactiveUserControl<LayoutViewModel>
     {
         public LayoutView()
         {
@@ -33,19 +33,9 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBlock LanguageTextBlock { get; set; } = null!;
-        private TextBlock KeyboardTextBlock { get; set; } = null!;
-        private TextBox CharsTextBox { get; set; } = null!;
-        private TextBlock DuplicateCharsTextBlock { get; set; } = null!;
-
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            this.LanguageTextBlock = this.FindControl<TextBlock>(nameof(this.LanguageTextBlock));
-            this.KeyboardTextBlock = this.FindControl<TextBlock>(nameof(this.KeyboardTextBlock));
-            this.CharsTextBox = this.FindControl<TextBox>(nameof(this.CharsTextBox));
-            this.DuplicateCharsTextBlock = this.FindControl<TextBlock>(nameof(this.DuplicateCharsTextBlock));
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/LoadableLayoutView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/LoadableLayoutView.xaml.cs
@@ -10,7 +10,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class LoadableLayoutView : ReactiveUserControl<LoadableLayoutViewModel>
+    public partial class LoadableLayoutView : ReactiveUserControl<LoadableLayoutViewModel>
     {
         public LoadableLayoutView()
         {
@@ -25,15 +25,6 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBlock NameTextBlock { get; set; } = null!;
-        private Button DeleteButton { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.NameTextBlock = this.FindControl<TextBlock>(nameof(this.NameTextBlock));
-            this.DeleteButton = this.FindControl<Button>(nameof(this.DeleteButton));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/LoadableLayoutsSettingsView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/LoadableLayoutsSettingsView.xaml.cs
@@ -14,7 +14,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class LoadableLayoutsSettingsView : ReactiveUserControl<LoadableLayoutsSettingsViewModel>
+    public partial class LoadableLayoutsSettingsView : ReactiveUserControl<LoadableLayoutsSettingsViewModel>
     {
         public LoadableLayoutsSettingsView()
         {
@@ -46,21 +46,9 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private ItemsControl Layouts { get; set; } = null!;
-        private ComboBox NewLayoutComboBox { get; set; } = null!;
-
-        private Button SaveButton { get; set; } = null!;
-        private Button CancelButton { get; set; } = null!;
-
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            this.Layouts = this.FindControl<ItemsControl>(nameof(this.Layouts));
-            this.NewLayoutComboBox = this.FindControl<ComboBox>(nameof(this.NewLayoutComboBox));
-
-            this.SaveButton = this.FindControl<Button>(nameof(this.SaveButton));
-            this.CancelButton = this.FindControl<Button>(nameof(this.CancelButton));
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/MainContentView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/MainContentView.xaml.cs
@@ -11,7 +11,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class MainContentView : ReactiveUserControl<MainContentViewModel>
+    public partial class MainContentView : ReactiveUserControl<MainContentViewModel>
     {
         public MainContentView()
         {
@@ -41,21 +41,6 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TabItem CharMappingTabItem { get; set; } = null!;
-        private TabItem PreferencesTabItem { get; set; } = null!;
-        private TabItem ConverterTabItem { get; set; } = null!;
-        private TabItem ConverterSettingsTabItem { get; set; } = null!;
-        private TabItem AboutTabItem { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.CharMappingTabItem = this.FindControl<TabItem>(nameof(this.CharMappingTabItem));
-            this.PreferencesTabItem = this.FindControl<TabItem>(nameof(this.PreferencesTabItem));
-            this.ConverterTabItem = this.FindControl<TabItem>(nameof(this.ConverterTabItem));
-            this.ConverterSettingsTabItem = this.FindControl<TabItem>(nameof(this.ConverterSettingsTabItem));
-            this.AboutTabItem = this.FindControl<TabItem>(nameof(this.AboutTabItem));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/MainWindow.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/MainWindow.xaml.cs
@@ -15,7 +15,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class MainWindow : ReactiveWindow<MainViewModel>
+    public partial class MainWindow : ReactiveWindow<MainViewModel>
     {
         public MainWindow()
         {
@@ -45,16 +45,7 @@ namespace KeyboardSwitch.Settings.Views
 #endif
         }
 
-        private ContentControl MainContent { get; set; } = null!;
-        private ContentControl ServiceViewContent { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.MainContent = this.FindControl<ContentControl>(nameof(this.MainContent));
-            this.ServiceViewContent = this.FindControl<ContentControl>(nameof(this.ServiceViewContent));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BringToForeground()
         {

--- a/KeyboardSwitch.Settings/Views/ModifierKeysSwitchView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/ModifierKeysSwitchView.xaml.cs
@@ -16,7 +16,7 @@ using ReactiveUI.Validation.Extensions;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class ModifierKeysSwitchView : ReactiveUserControl<ModifierKeysSwitchViewModel>
+    public partial class ModifierKeysSwitchView : ReactiveUserControl<ModifierKeysSwitchViewModel>
     {
         public ModifierKeysSwitchView()
         {
@@ -52,35 +52,9 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private ComboBox ForwardComboBox { get; set; } = null!;
-        private ComboBox BackwardComboBox { get; set; } = null!;
-
-        private NumericUpDown PressCountUpDown { get; set; } = null!;
-        private NumericUpDown WaitMillisecondsUpDown { get; set; } = null!;
-
-        private TextBlock PressCountValidationTextBlock { get; set; } = null!;
-        private TextBlock WaitMillisecondsValidationTextBlock { get; set; } = null!;
-        private TextBlock SwitchMethodsValidationTextBlock { get; set; } = null!;
-
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            this.ForwardComboBox = this.FindControl<ComboBox>(nameof(this.ForwardComboBox));
-            this.BackwardComboBox = this.FindControl<ComboBox>(nameof(this.BackwardComboBox));
-
-            this.PressCountUpDown = this.FindControl<NumericUpDown>(nameof(this.PressCountUpDown));
-            this.WaitMillisecondsUpDown = this.FindControl<NumericUpDown>(nameof(this.WaitMillisecondsUpDown));
-
-            this.PressCountValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.PressCountValidationTextBlock));
-
-            this.WaitMillisecondsValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.WaitMillisecondsValidationTextBlock));
-
-            this.SwitchMethodsValidationTextBlock = this.FindControl<TextBlock>(
-                nameof(this.SwitchMethodsValidationTextBlock));
-
             var allModifiers = new List<ModifierKeys> { ModifierKeys.Alt, ModifierKeys.Ctrl, ModifierKeys.Shift }
                 .GetPowerSet()
                 .Select(modifiers => modifiers.ToList())

--- a/KeyboardSwitch.Settings/Views/PreferencesView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/PreferencesView.xaml.cs
@@ -14,7 +14,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class PreferencesView : ReactiveUserControl<PreferencesViewModel>
+    public partial class PreferencesView : ReactiveUserControl<PreferencesViewModel>
     {
         public PreferencesView()
         {
@@ -62,35 +62,9 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private CheckBox InstantSwitchingCheckBox { get; set; } = null!;
-        private CheckBox SwitchLayoutCheckBox { get; set; } = null!;
-        private CheckBox StartupCheckBox { get; set; } = null!;
-        private CheckBox ShowRemovedLayoutsMessageCheckBox { get; set; } = null!;
-
-        private ComboBox SwitchModeComboBox { get; set; } = null!;
-        private ContentControl PreferencesContent { get; set; } = null!;
-
-        private StackPanel ActionPanel { get; set; } = null!;
-        private Button SaveButton { get; set; } = null!;
-        private Button CancelButton { get; set; } = null!;
-
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-
-            this.InstantSwitchingCheckBox = this.FindControl<CheckBox>(nameof(this.InstantSwitchingCheckBox));
-            this.SwitchLayoutCheckBox = this.FindControl<CheckBox>(nameof(this.SwitchLayoutCheckBox));
-            this.StartupCheckBox = this.FindControl<CheckBox>(nameof(this.StartupCheckBox));
-            this.ShowRemovedLayoutsMessageCheckBox = this.FindControl<CheckBox>(
-                nameof(this.ShowRemovedLayoutsMessageCheckBox));
-
-            this.SwitchModeComboBox = this.FindControl<ComboBox>(nameof(this.SwitchModeComboBox));
-            this.PreferencesContent = this.FindControl<ContentControl>(nameof(this.PreferencesContent));
-
-            this.ActionPanel = this.FindControl<StackPanel>(nameof(this.ActionPanel));
-            this.SaveButton = this.FindControl<Button>(nameof(this.SaveButton));
-            this.CancelButton = this.FindControl<Button>(nameof(this.CancelButton));
-
             this.SwitchModeComboBox.Items = new List<string> { Messages.ModifierKeys, Messages.HotKey };
         }
     }

--- a/KeyboardSwitch.Settings/Views/SandboxView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/SandboxView.xaml.cs
@@ -3,7 +3,7 @@ using Avalonia.Markup.Xaml;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class SandboxView : UserControl
+    public partial class SandboxView : UserControl
     {
         public SandboxView()
             => this.InitializeComponent();

--- a/KeyboardSwitch.Settings/Views/ServiceView.xaml.cs
+++ b/KeyboardSwitch.Settings/Views/ServiceView.xaml.cs
@@ -11,7 +11,7 @@ using ReactiveUI;
 
 namespace KeyboardSwitch.Settings.Views
 {
-    public class ServiceView : ReactiveUserControl<ServiceViewModel>
+    public partial class ServiceView : ReactiveUserControl<ServiceViewModel>
     {
         public ServiceView()
         {
@@ -60,23 +60,6 @@ namespace KeyboardSwitch.Settings.Views
             this.InitializeComponent();
         }
 
-        private TextBlock ServiceRunningTextBlock { get; set; } = null!;
-        private TextBlock ServiceNotRunningTextBlock { get; set; } = null!;
-        private TextBlock ServiceShuttingDownTextBlock { get; set; } = null!;
-        private Button StartServiceButton { get; set; } = null!;
-        private Button StopServiceButton { get; set; } = null!;
-        private Button KillServiceButton { get; set; } = null!;
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-
-            this.ServiceRunningTextBlock = this.FindControl<TextBlock>(nameof(this.ServiceRunningTextBlock));
-            this.ServiceNotRunningTextBlock = this.FindControl<TextBlock>(nameof(this.ServiceNotRunningTextBlock));
-            this.ServiceShuttingDownTextBlock = this.FindControl<TextBlock>(nameof(this.ServiceShuttingDownTextBlock));
-            this.StartServiceButton = this.FindControl<Button>(nameof(this.StartServiceButton));
-            this.StopServiceButton = this.FindControl<Button>(nameof(this.StopServiceButton));
-            this.KillServiceButton = this.FindControl<Button>(nameof(this.KillServiceButton));
-        }
+        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }


### PR DESCRIPTION
This PR incorporates the [Avalonia.NameGenerator](https://github.com/avaloniaui/avalonia.namegenerator) tool that allows avoiding calling the `FindControl<T>` extension method manually. The generator produces strongly typed references to Avalonia controls and puts them into a partial class, for every class referenced as `x:Class` from XAML files included as `<AdditionalFiles />`.