### PR TITLE
Upgrade Avalonia.NameGenerator

### DIFF
--- a/KeyboardSwitch.Settings/KeyboardSwitch.Settings.csproj
+++ b/KeyboardSwitch.Settings/KeyboardSwitch.Settings.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="System.Interactive" Version="5.0.0" />
     <PackageReference Include="System.Interactive.Async" Version="5.0.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
-    <PackageReference Include="XamlNameReferenceGenerator" Version="0.4.1" />
+    <PackageReference Include="XamlNameReferenceGenerator" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KeyboardSwitch.Settings/Views/AboutView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/AboutView.axaml.cs
@@ -3,8 +3,6 @@ using System.Globalization;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -19,6 +17,7 @@ namespace KeyboardSwitch.Settings.Views
     {
         public AboutView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.VersionTextBlock.Text = String.Format(
@@ -43,11 +42,7 @@ namespace KeyboardSwitch.Settings.Views
 
                 this.BindElementsVisibility(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BindElementsVisibility(CompositeDisposable disposables)
         {

--- a/KeyboardSwitch.Settings/Views/CharMappingView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/CharMappingView.axaml.cs
@@ -1,8 +1,6 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -16,19 +14,16 @@ namespace KeyboardSwitch.Settings.Views
     {
         public CharMappingView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.OneWayBind(this.ViewModel, vm => vm.Layouts, v => v.Layouts.Items)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindCommands(disposables);
                 this.BindTextBlocks(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BindCommands(CompositeDisposable disposables)
         {

--- a/KeyboardSwitch.Settings/Views/CharacterView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/CharacterView.axaml.cs
@@ -2,11 +2,8 @@ using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -21,6 +18,7 @@ namespace KeyboardSwitch.Settings.Views
     {
         public CharacterView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.Bind(
@@ -29,7 +27,7 @@ namespace KeyboardSwitch.Settings.Views
                     v => v.CharBox.Text,
                     ch => ch.ToString(),
                     text => text.Length > 0 ? text[0] : MissingCharacter)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.CharBox.GetObservable(KeyDownEvent, RoutingStrategies.Tunnel)
                     .Do(e => e.Handled = true)
@@ -38,11 +36,7 @@ namespace KeyboardSwitch.Settings.Views
                     .BindTo(this, v => v.CharBox.Text)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private string KeyToString(KeyEventArgs e)
             => e.Key switch

--- a/KeyboardSwitch.Settings/Views/ConverterSettingsView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/ConverterSettingsView.axaml.cs
@@ -1,7 +1,5 @@
 using System.Reactive.Disposables;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -16,10 +14,11 @@ namespace KeyboardSwitch.Settings.Views
     {
         public ConverterSettingsView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.OneWayBind(this.ViewModel, vm => vm.CustomLayouts, v => v.Layouts.Items)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindValidation(
                     this.ViewModel, vm => vm!.LayoutNamesAreUniqueRule, v => v.CustomLayoutsValidationTextBlock.Text)
@@ -53,12 +52,8 @@ namespace KeyboardSwitch.Settings.Views
                 this.WhenAnyValue(v => v.ViewModel.LoadableLayoutsSettingsViewModel)
                     .WhereNotNull()
                     .BindTo(this, v => v.LoadableLayoutsControl.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/ConverterView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/ConverterView.axaml.cs
@@ -3,10 +3,8 @@ using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using DynamicData;
@@ -25,17 +23,14 @@ namespace KeyboardSwitch.Settings.Views
     {
         public ConverterView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.BindConverterVisibility(disposables);
                 this.BindControls(disposables);
                 this.BindCommands(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BindConverterVisibility(CompositeDisposable disposables)
         {
@@ -56,22 +51,22 @@ namespace KeyboardSwitch.Settings.Views
         private void BindControls(CompositeDisposable disposables)
         {
             this.Bind(this.ViewModel, vm => vm.SourceText, v => v.SourceTextBox.Text)
-                ?.DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.OneWayBind(this.ViewModel, vm => vm.TargetText, v => v.TargetTextBox.Text)
-                ?.DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.OneWayBind(this.ViewModel, vm => vm.Layouts, v => v.SourceLayoutComboBox.Items)
-                ?.DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.OneWayBind(this.ViewModel, vm => vm.Layouts, v => v.TargetLayoutComboBox.Items)
-                ?.DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.Bind(this.ViewModel, vm => vm.SourceLayout, v => v.SourceLayoutComboBox.SelectedItem)
-                ?.DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.Bind(this.ViewModel, vm => vm.TargetLayout, v => v.TargetLayoutComboBox.SelectedItem)
-                ?.DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.ViewModel.Layouts
                 .ToObservableChangeSet()
@@ -92,7 +87,7 @@ namespace KeyboardSwitch.Settings.Views
         private void BindCommands(CompositeDisposable disposables)
         {
             this.BindCommand(this.ViewModel, vm => vm.SwapLayouts, v => v.SwapButton)
-                    .DisposeWith(disposables);
+                .DisposeWith(disposables);
 
             this.BindCommand(this.ViewModel, vm => vm.Convert, v => v.ConvertButton)
                 .DisposeWith(disposables);

--- a/KeyboardSwitch.Settings/Views/CustomLayoutView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/CustomLayoutView.axaml.cs
@@ -4,7 +4,6 @@ using System.Reactive.Linq;
 
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -18,13 +17,14 @@ namespace KeyboardSwitch.Settings.Views
     {
         public CustomLayoutView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.Bind(this.ViewModel, vm => vm.Name, v => v.NameTextBox.Text)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.Chars, v => v.CharsTextBox.Text)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindCommand(this.ViewModel, vm => vm.Delete, v => v.DeleteButton)
                     .DisposeWith(disposables);
@@ -39,10 +39,6 @@ namespace KeyboardSwitch.Settings.Views
                 this.BindValidation(this.ViewModel, vm => vm.Chars, v => v.DuplicateCharsTextBlock.Text)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/HotKeySwitchView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/HotKeySwitchView.axaml.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -20,16 +18,30 @@ namespace KeyboardSwitch.Settings.Views
     {
         public HotKeySwitchView()
         {
+            this.InitializeComponent();
+            this.ModifierKeysComboBox.Items = new List<ModifierKeys>
+                {
+                    ModifierKeys.Alt, ModifierKeys.Ctrl, ModifierKeys.Shift
+                }
+                .GetPowerSet()
+                .Select(modifiers => modifiers.ToList())
+                .Where(modifiers => modifiers.Count > 1)
+                .OrderBy(modifiers => modifiers.Count)
+                .Select(modifiers => modifiers.Flatten())
+                .Select(Convert.ModifierKeysToString)
+                .Where(value => value != null)
+                .ToList();
+
             this.WhenActivated(disposables =>
             {
                 this.Bind(this.ViewModel, vm => vm.ModifierKeys, v => v.ModifierKeysComboBox.SelectedItem)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.Forward, v => v.ForwardContent.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.Backward, v => v.BackwardContent.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindValidation(
                         this.ViewModel, vm => vm!.ForwardIsValidRule, v => v.ForwardValidationTextBlock.Text)
@@ -55,25 +67,6 @@ namespace KeyboardSwitch.Settings.Views
                         v => v.SwitchMethodsValidationTextBlock.Text)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-            this.ModifierKeysComboBox.Items = new List<ModifierKeys>
-                {
-                    ModifierKeys.Alt, ModifierKeys.Ctrl, ModifierKeys.Shift
-                }
-                .GetPowerSet()
-                .Select(modifiers => modifiers.ToList())
-                .Where(modifiers => modifiers.Count > 1)
-                .OrderBy(modifiers => modifiers.Count)
-                .Select(modifiers => modifiers.Flatten())
-                .Select(Convert.ModifierKeysToString)
-                .Where(value => value != null)
-                .ToList();
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/LayoutView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/LayoutView.axaml.cs
@@ -1,7 +1,5 @@
 using System.Reactive.Disposables;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -15,27 +13,21 @@ namespace KeyboardSwitch.Settings.Views
     {
         public LayoutView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.OneWayBind(this.ViewModel, vm => vm.LanguageName, v => v.LanguageTextBlock.Text)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.KeyboardName, v => v.KeyboardTextBlock.Text)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.Chars, v => v.CharsTextBox.Text)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindValidation(this.ViewModel, vm => vm.Chars, v => v.DuplicateCharsTextBlock.Text)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/LoadableLayoutView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/LoadableLayoutView.axaml.cs
@@ -1,7 +1,5 @@
 using System.Reactive.Disposables;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -14,6 +12,7 @@ namespace KeyboardSwitch.Settings.Views
     {
         public LoadableLayoutView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.NameTextBlock.Text = this.ViewModel.Layout.Name;
@@ -21,10 +20,6 @@ namespace KeyboardSwitch.Settings.Views
                 this.BindCommand(this.ViewModel, vm => vm.Delete, v => v.DeleteButton)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/LoadableLayoutsSettingsView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/LoadableLayoutsSettingsView.axaml.cs
@@ -2,10 +2,8 @@ using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -18,13 +16,14 @@ namespace KeyboardSwitch.Settings.Views
     {
         public LoadableLayoutsSettingsView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.OneWayBind(this.ViewModel, vm => vm.AddedLayouts, v => v.Layouts.Items)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.AddableLayouts, v => v.NewLayoutComboBox.Items)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.NewLayoutComboBox.GetObservable(SelectingItemsControl.SelectionChangedEvent)
                     .Where(e => e.AddedItems.Count > 0)
@@ -42,13 +41,6 @@ namespace KeyboardSwitch.Settings.Views
                 this.BindCommand(this.ViewModel, vm => vm.Finish, v => v.CancelButton, Observable.Return(false))
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/MainContentView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/MainContentView.axaml.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Reactive.Disposables;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -15,32 +13,29 @@ namespace KeyboardSwitch.Settings.Views
     {
         public MainContentView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.OneWayBind(this.ViewModel, vm => vm.CharMappingViewModel, v => v.CharMappingTabItem.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.PreferencesViewModel, v => v.PreferencesTabItem.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.ConverterViewModel, v => v.ConverterTabItem.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(
                     this.ViewModel, vm => vm.ConverterSettingsViewModel, v => v.ConverterSettingsTabItem.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.AboutViewModel, v => v.AboutTabItem.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.ViewModel.OpenAboutTab
                     .Subscribe(_ => this.AboutTabItem.IsSelected = true)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }

--- a/KeyboardSwitch.Settings/Views/MainWindow.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/MainWindow.axaml.cs
@@ -1,11 +1,9 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -19,13 +17,14 @@ namespace KeyboardSwitch.Settings.Views
     {
         public MainWindow()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.OneWayBind(this.ViewModel, vm => vm.MainContentViewModel, v => v.MainContent.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.ServiceViewModel, v => v.ServiceViewContent.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.ViewModel.OpenExternally
                     .Subscribe(this.BringToForeground)
@@ -38,14 +37,7 @@ namespace KeyboardSwitch.Settings.Views
                     .InvokeCommand(this.ViewModel.OpenAboutTab)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
         private void BringToForeground()
         {

--- a/KeyboardSwitch.Settings/Views/ModifierKeysSwitchView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/ModifierKeysSwitchView.axaml.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -20,19 +18,32 @@ namespace KeyboardSwitch.Settings.Views
     {
         public ModifierKeysSwitchView()
         {
+            this.InitializeComponent();
+            var allModifiers = new List<ModifierKeys> { ModifierKeys.Alt, ModifierKeys.Ctrl, ModifierKeys.Shift }
+                .GetPowerSet()
+                .Select(modifiers => modifiers.ToList())
+                .OrderBy(modifiers => modifiers.Count)
+                .Skip(1)
+                .Select(modifiers => modifiers.Flatten())
+                .Select(Convert.ModifierKeysToString)
+                .Where(value => value != null)
+                .ToList();
+
+            this.ForwardComboBox.Items = allModifiers;
+            this.BackwardComboBox.Items = allModifiers;
             this.WhenActivated(disposables =>
             {
                 this.Bind(this.ViewModel, vm => vm.ForwardModifierKeys, v => v.ForwardComboBox.SelectedItem)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.BackwardModifierKeys, v => v.BackwardComboBox.SelectedItem)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.PressCount, v => v.PressCountUpDown.Value)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.WaitMilliseconds, v => v.WaitMillisecondsUpDown.Value)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindValidation(
                         this.ViewModel, vm => vm.PressCount, v => v.PressCountValidationTextBlock.Text)
@@ -48,25 +59,6 @@ namespace KeyboardSwitch.Settings.Views
                         v => v.SwitchMethodsValidationTextBlock.Text)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-            var allModifiers = new List<ModifierKeys> { ModifierKeys.Alt, ModifierKeys.Ctrl, ModifierKeys.Shift }
-                .GetPowerSet()
-                .Select(modifiers => modifiers.ToList())
-                .OrderBy(modifiers => modifiers.Count)
-                .Skip(1)
-                .Select(modifiers => modifiers.Flatten())
-                .Select(Convert.ModifierKeysToString)
-                .Where(value => value != null)
-                .ToList();
-
-            this.ForwardComboBox.Items = allModifiers;
-            this.BackwardComboBox.Items = allModifiers;
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/PreferencesView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/PreferencesView.axaml.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Common;
@@ -18,25 +16,27 @@ namespace KeyboardSwitch.Settings.Views
     {
         public PreferencesView()
         {
+            this.InitializeComponent();
+            this.SwitchModeComboBox.Items = new List<string> { Messages.ModifierKeys, Messages.HotKey };
             this.WhenActivated(disposables =>
             {
                 this.Bind(this.ViewModel, vm => vm.SwitchMode, v => v.SwitchModeComboBox.SelectedItem)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.InstantSwitching, v => v.InstantSwitchingCheckBox.IsChecked)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.SwitchLayout, v => v.SwitchLayoutCheckBox.IsChecked)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(this.ViewModel, vm => vm.Startup, v => v.StartupCheckBox.IsChecked)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.Bind(
                     this.ViewModel,
                     vm => vm.ShowUninstalledLayoutsMessage,
                     v => v.ShowRemovedLayoutsMessageCheckBox.IsChecked)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 Observable.CombineLatest(
                         this.WhenAnyObservable(v => v.ViewModel.HotKeySwitchViewModel.Valid),
@@ -46,7 +46,7 @@ namespace KeyboardSwitch.Settings.Views
                     .DisposeWith(disposables);
 
                 this.OneWayBind(this.ViewModel, vm => vm.Content, v => v.PreferencesContent.Content)
-                    ?.DisposeWith(disposables);
+                    .DisposeWith(disposables);
 
                 this.BindCommand(this.ViewModel, vm => vm.Save, v => v.SaveButton)
                     .DisposeWith(disposables);
@@ -58,14 +58,6 @@ namespace KeyboardSwitch.Settings.Views
                     .BindTo(this, v => v.ActionPanel.IsVisible)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-            this.SwitchModeComboBox.Items = new List<string> { Messages.ModifierKeys, Messages.HotKey };
         }
     }
 }

--- a/KeyboardSwitch.Settings/Views/SandboxView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/SandboxView.axaml.cs
@@ -1,14 +1,9 @@
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace KeyboardSwitch.Settings.Views
 {
     public partial class SandboxView : UserControl
     {
-        public SandboxView()
-            => this.InitializeComponent();
-
-        private void InitializeComponent()
-            => AvaloniaXamlLoader.Load(this);
+        public SandboxView() => this.InitializeComponent();
     }
 }

--- a/KeyboardSwitch.Settings/Views/ServiceView.axaml.cs
+++ b/KeyboardSwitch.Settings/Views/ServiceView.axaml.cs
@@ -1,8 +1,6 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.ReactiveUI;
 
 using KeyboardSwitch.Settings.Core.ViewModels;
@@ -15,6 +13,7 @@ namespace KeyboardSwitch.Settings.Views
     {
         public ServiceView()
         {
+            this.InitializeComponent();
             this.WhenActivated(disposables =>
             {
                 this.WhenAnyValue(v => v.ViewModel.ServiceStatus)
@@ -56,10 +55,6 @@ namespace KeyboardSwitch.Settings.Views
                 this.BindCommand(this.ViewModel, vm => vm.KillService, v => v.KillServiceButton)
                     .DisposeWith(disposables);
             });
-
-            this.InitializeComponent();
         }
-
-        private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
     }
 }


### PR DESCRIPTION
This PR bumps [Avalonia.NameGenerator](https://github.com/AvaloniaUI/Avalonia.NameGenerator/releases) version. The generator can now generate partial `InitializeComponent` methods. Such methods call `FindControl` and `AvaloniaXamlLoader.Load(this)` methods internally. Also, I removed the `?.` operators from `OneWayBind` as the signature of that binding method has changed in newer ReactiveUI versions. 